### PR TITLE
Feature/delete users by post count

### DIFF
--- a/include/base/users/class-bd-user-meta-box-module.php
+++ b/include/base/users/class-bd-user-meta-box-module.php
@@ -68,7 +68,9 @@ abstract class BD_User_Meta_Box_Module extends BD_Meta_Box_Module {
 	 * @return bool True if the user can be deleted, false otherwise.
 	 */
 	protected function can_delete_by_post_count( $delete_options, $user ) {
-		if ( $delete_options['no_posts'] && count_user_posts( $user->ID ) > 0 ) {
+		if ( $delete_options['no_posts'] &&
+			 array_key_exists( 'post_type', $delete_options ) &&
+			 count_user_posts( $user->ID, $delete_options['post_type'] ) > 0 ) {
 			return false;
 		}
 

--- a/include/base/users/class-bd-user-meta-box-module.php
+++ b/include/base/users/class-bd-user-meta-box-module.php
@@ -63,14 +63,12 @@ abstract class BD_User_Meta_Box_Module extends BD_Meta_Box_Module {
 	 * @access protected
 	 *
 	 * @param array  $delete_options Delete Options.
-	 * @param object $user           User objet that needs to be deleted.
+	 * @param object $user           User object that needs to be deleted.
 	 *
 	 * @return bool True if the user can be deleted, false otherwise.
 	 */
 	protected function can_delete_by_post_count( $delete_options, $user ) {
-		if ( $delete_options['no_posts'] &&
-			 array_key_exists( 'post_type', $delete_options ) &&
-			 count_user_posts( $user->ID, $delete_options['post_type'] ) > 0 ) {
+		if ( $delete_options['no_posts'] && count_user_posts( $user->ID, get_post_types( array( 'public' => true ) ) ) > 0 ) {
 			return false;
 		}
 

--- a/include/base/users/class-bd-user-meta-box-module.php
+++ b/include/base/users/class-bd-user-meta-box-module.php
@@ -68,9 +68,7 @@ abstract class BD_User_Meta_Box_Module extends BD_Meta_Box_Module {
 	 * @return bool True if the user can be deleted, false otherwise.
 	 */
 	protected function can_delete_by_post_count( $delete_options, $user ) {
-		if ( $delete_options['no_posts'] &&
-			 array_key_exists( 'post_type', $delete_options ) &&
-			 count_user_posts( $user->ID, $delete_options['post_type'] ) > 0 ) {
+		if ( $delete_options['no_posts'] && count_user_posts( $user->ID ) > 0 ) {
 			return false;
 		}
 

--- a/include/users/modules/class-bulk-delete-users-by-user-meta.php
+++ b/include/users/modules/class-bulk-delete-users-by-user-meta.php
@@ -115,6 +115,7 @@ class Bulk_Delete_Users_By_User_Meta extends BD_User_Meta_Box_Module {
 		$delete_options['meta_key']       = array_get( $_POST, 'smbd_u_meta_key' );
 		$delete_options['meta_compare']   = array_get( $_POST, 'smbd_u_meta_compare', '=' );
 		$delete_options['meta_value']     = array_get( $_POST, 'smbd_u_meta_value' );
+		$delete_options['post_type']      = array_merge( array( 'post', 'page' ), get_post_types( array( '_builtin' => false ) ) );
 
 		$this->process_user_delete( $delete_options );
 	}

--- a/include/users/modules/class-bulk-delete-users-by-user-meta.php
+++ b/include/users/modules/class-bulk-delete-users-by-user-meta.php
@@ -115,7 +115,6 @@ class Bulk_Delete_Users_By_User_Meta extends BD_User_Meta_Box_Module {
 		$delete_options['meta_key']       = array_get( $_POST, 'smbd_u_meta_key' );
 		$delete_options['meta_compare']   = array_get( $_POST, 'smbd_u_meta_compare', '=' );
 		$delete_options['meta_value']     = array_get( $_POST, 'smbd_u_meta_value' );
-		$delete_options['post_type']      = array_merge( array( 'post', 'page' ), get_post_types( array( '_builtin' => false ) ) );
 
 		$this->process_user_delete( $delete_options );
 	}

--- a/include/users/modules/class-bulk-delete-users-by-user-role.php
+++ b/include/users/modules/class-bulk-delete-users-by-user-role.php
@@ -104,7 +104,7 @@ class Bulk_Delete_Users_By_User_Role extends BD_User_Meta_Box_Module {
 	public function process() {
 		$delete_options                   = array();
 		$delete_options['selected_roles'] = array_get( $_POST, 'smbd_u_roles' );
-		$delete_options['post_type']      = array_merge( array( 'post', 'page' ), get_post_types( array( '_builtin' => false ) ) );
+
 		$this->process_user_delete( $delete_options );
 	}
 

--- a/include/users/modules/class-bulk-delete-users-by-user-role.php
+++ b/include/users/modules/class-bulk-delete-users-by-user-role.php
@@ -104,7 +104,6 @@ class Bulk_Delete_Users_By_User_Role extends BD_User_Meta_Box_Module {
 	public function process() {
 		$delete_options                   = array();
 		$delete_options['selected_roles'] = array_get( $_POST, 'smbd_u_roles' );
-		$delete_options['post_type']      = array_merge( array( 'post', 'page' ), get_post_types( array( '_builtin' => false ) ) );
 		$this->process_user_delete( $delete_options );
 	}
 

--- a/include/users/modules/class-bulk-delete-users-by-user-role.php
+++ b/include/users/modules/class-bulk-delete-users-by-user-role.php
@@ -104,7 +104,7 @@ class Bulk_Delete_Users_By_User_Role extends BD_User_Meta_Box_Module {
 	public function process() {
 		$delete_options                   = array();
 		$delete_options['selected_roles'] = array_get( $_POST, 'smbd_u_roles' );
-
+		$delete_options['post_type']      = array_merge( array( 'post', 'page' ), get_post_types( array( '_builtin' => false ) ) );
 		$this->process_user_delete( $delete_options );
 	}
 


### PR DESCRIPTION
From the `dev/5.6` commits, a similar PR has been merged ([Here](eb64666dd7a04acf1415b5eeaea448b6848b1b29) is the merge commit). Yet, the following code changes were needed for the to-do to be completely fixed.

Fix for the following:

https://github.com/sudar/bulk-delete/issues/36 Delete users by post count, counts only "post" post type