### PR TITLE
Add filters and actions to enable support for old add-ons

### DIFF
--- a/include/Core/Base/BaseDeletePage.php
+++ b/include/Core/Base/BaseDeletePage.php
@@ -181,6 +181,13 @@ abstract class BaseDeletePage extends BasePage {
 			$module->register( $this->hook_suffix, $this->page_slug );
 			$this->actions[] = $module->get_action();
 		}
+
+		/**
+		 * Triggered after all post modules are registered.
+		 *
+		 * @since 6.0.0
+		 */
+		do_action( 'bd_add_meta_box_for_posts' );
 	}
 
 	/**

--- a/include/Core/Base/BasePage.php
+++ b/include/Core/Base/BasePage.php
@@ -161,7 +161,17 @@ abstract class BasePage {
 	 * @return bool True if nonce is verified, False otherwise.
 	 */
 	public function verify_nonce( $result, $action ) {
-		if ( in_array( $action, $this->actions, true ) ) {
+		/**
+		 * List of actions for page.
+		 *
+		 * @param array    $actions Actions.
+		 * @param BasePage $page    Page objects.
+		 *
+		 * @since 6.0.0
+		 */
+		$page_actions = apply_filters( 'bd_page_actions', $this->actions, $this );
+
+		if ( in_array( $action, $page_actions, true ) ) {
 			if ( check_admin_referer( "bd-{$this->page_slug}", "bd-{$this->page_slug}-nonce" ) ) {
 				return true;
 			}

--- a/include/deprecated/support-old-addons.php
+++ b/include/deprecated/support-old-addons.php
@@ -61,3 +61,36 @@ function bd_load_deprecated_page_modules( $page ) {
 	$trash_module->load_if_needed( $page );
 }
 add_action( 'bd_after_pages_modules', 'bd_load_deprecated_page_modules' );
+
+/**
+ * Enable nonce checks for old post add-ons.
+ *
+ * This is needed only to do automatic nonce checks for old add-ons and will be eventually removed.
+ *
+ * @since 6.0.0
+ *
+ * @param array                                 $actions Actions.
+ * @param \BulkWP\BulkDelete\Core\Base\BasePage $page    Page to which actions might be added.
+ *
+ * @return array List of modified actions.
+ */
+function bd_enable_nonce_check_for_old_post_addons( $actions, $page ) {
+	if ( 'bulk-delete-posts' !== $page->get_page_slug() ) {
+		return $actions;
+	}
+
+	if ( class_exists( '\Bulk_Delete_Posts_By_User' ) ) {
+		$actions[] = 'delete_posts_by_user';
+	}
+
+	if ( class_exists( '\Bulk_Delete_Posts_By_Attachment' ) ) {
+		$actions[] = 'delete_posts_by_attachment';
+	}
+
+	if ( class_exists( '\Bulk_Delete_Posts_By_Content' ) ) {
+		$actions[] = 'delete_posts_by_content';
+	}
+
+	return $actions;
+}
+add_filter( 'bd_page_actions', 'bd_enable_nonce_check_for_old_post_addons', 10, 2 );


### PR DESCRIPTION
Fix #398

Support for following add-ons are added in this commit

- Bulk Delete Posts by User - v0.1
- Bulk Delete Posts by Attachment - v0.1
- Bulk Delete Posts by Content - v0.2