### PR TITLE
Fix #457

### DIFF
--- a/include/Core/Posts/Modules/DeletePostsByCategoryModule.php
+++ b/include/Core/Posts/Modules/DeletePostsByCategoryModule.php
@@ -40,8 +40,8 @@ class DeletePostsByCategoryModule extends PostsModule {
 
 			<h4><?php _e( 'Select the categories from which you want to delete posts', 'bulk-delete' ); ?></h4>
 			<p>
-				<?php _e( 'Note: The post count below for each category is the total number of posts in that category, irrespective of post type', 'bulk-delete' ); ?>
-			.</p>
+				<?php _e( 'Note: The post count below for each category is the total number of posts in that category, irrespective of post type.', 'bulk-delete' ); ?>
+			</p>
 
 			<table class="form-table">
 				<tr>

--- a/tests/wp-unit/include/Core/Pages/Modules/DeletePagesByStatusModuleTest.php
+++ b/tests/wp-unit/include/Core/Pages/Modules/DeletePagesByStatusModuleTest.php
@@ -143,7 +143,7 @@ class DeletePagesByStatusModuleTest extends WPCoreUnitTestCase {
 	/**
 	 * Test date filter (within the last x days) with two post status.
 	 */
-	public function test_that_pages_that_are_posted_within_the_last_x_days_can_be_deleted() {
+	public function test_that_pages_that_are_posted_within_the_last_x_days_can_be_trashed() {
 		$date = date( 'Y-m-d H:i:s', strtotime( '-3 day' ) );
 
 		$published_pages = $this->factory->post->create_many( 10, array(
@@ -187,7 +187,7 @@ class DeletePagesByStatusModuleTest extends WPCoreUnitTestCase {
 	/**
 	 * Test batch deletion with two post status.
 	 */
-	public function test_that_pages_can_be_deleted_in_batches() {
+	public function test_that_pages_can_be_trashed_in_batches() {
 		$published_pages = $this->factory->post->create_many( 50, array(
 			'post_type'   => 'page',
 			'post_status' => 'publish',


### PR DESCRIPTION
Removed whitespace before period and moved the period inside translatable _e() function.