### PR TITLE
PR: Delete Terms by Name - Split data provider into multiple functions and add missing combinations (#478)

### DIFF
--- a/include/Core/Terms/Modules/DeleteTermsByNameModule.php
+++ b/include/Core/Terms/Modules/DeleteTermsByNameModule.php
@@ -18,8 +18,8 @@ class DeleteTermsByNameModule extends TermsModule {
 		$this->meta_box_slug = 'bd_delete_terms_by_name';
 		$this->action        = 'delete_terms_by_name';
 		$this->messages      = array(
-			'box_label'  => __( 'Delete Terms by Name', 'bulk-delete' ),
-			'scheduled'  => __( 'The selected terms are scheduled for deletion', 'bulk-delete' ),
+			'box_label' => __( 'Delete Terms by Name', 'bulk-delete' ),
+			'scheduled' => __( 'The selected terms are scheduled for deletion', 'bulk-delete' ),
 		);
 	}
 

--- a/include/Core/Terms/Modules/DeleteTermsByNameModule.php
+++ b/include/Core/Terms/Modules/DeleteTermsByNameModule.php
@@ -102,8 +102,8 @@ class DeleteTermsByNameModule extends TermsModule {
 	 */
 	protected function get_terms_that_are_equal_to( $value, $options ) {
 		$query = array(
-			'taxonomy'   => $options['taxonomy'],
-			'name__like' => $value,
+			'taxonomy' => $options['taxonomy'],
+			'name'     => $value,
 		);
 
 		return $this->query_terms( $query );
@@ -119,8 +119,8 @@ class DeleteTermsByNameModule extends TermsModule {
 	 */
 	protected function get_terms_that_are_not_equal_to( $value, $options ) {
 		$name_like_args = array(
-			'name__like' => $value,
-			'taxonomy'   => $options['taxonomy'],
+			'name'     => $value,
+			'taxonomy' => $options['taxonomy'],
 		);
 
 		$query = array(

--- a/include/Core/Terms/TermsModule.php
+++ b/include/Core/Terms/TermsModule.php
@@ -22,11 +22,6 @@ abstract class TermsModule extends BaseModule {
 	 */
 	abstract protected function get_term_ids_to_delete( $options );
 
-	/**
-	 * Item type.
-	 *
-	 * @var string Item Type. Possible values 'posts', 'pages', 'users', 'terms' etc.
-	 */
 	protected $item_type = 'terms';
 
 	/**
@@ -107,9 +102,10 @@ abstract class TermsModule extends BaseModule {
 	 */
 	protected function query_terms( $query ) {
 		$defaults = array(
-			'fields'     => 'ids', // retrieve only ids.
-			'hide_empty' => false,
-			'count'      => false,
+			'fields'                 => 'ids', // retrieve only ids.
+			'hide_empty'             => false,
+			'count'                  => false,
+			'update_term_meta_cache' => false,
 		);
 
 		$query = wp_parse_args( $query, $defaults );

--- a/tests/wp-unit/include/Core/Posts/Modules/DeletePostsByRevisionModuleTest.php
+++ b/tests/wp-unit/include/Core/Posts/Modules/DeletePostsByRevisionModuleTest.php
@@ -27,13 +27,15 @@ class DeletePostsByRevisionModuleTest extends WPCoreUnitTestCase {
 	}
 
 	/**
-	 * Test delete revisions for a single post
+	 * Test thet post revisions can be deleted form a single post
 	 */
-	public function test_delete_revisions_for_single_post() {
-		
-		$post_id = $this->factory->post->create( array(
-			'post_type' => 'post',
-		) );
+	public function test_that_post_revisions_can_be_deleted_from_single_post() {
+
+		$post_id = $this->factory->post->create(
+			array(
+				'post_type' => 'post',
+			)
+		);
 
 		$revision_post_1 = array(
 			'ID'           => $post_id,
@@ -52,27 +54,28 @@ class DeletePostsByRevisionModuleTest extends WPCoreUnitTestCase {
 		wp_update_post( $revision_post_2 );
 
 		$delete_options = array(
-			'revisions'    => 'revisions',
-			'limit_to'     => -1,
-			'restrict'     => false,
-			'force_delete' => false,
+			'revisions' => 'revisions',
 		);
 
 		$posts_deleted = $this->module->delete( $delete_options );
 		$this->assertEquals( 2, $posts_deleted );
 
+		$post = get_post( $post_id );
+		$this->assertEquals( $post->ID, $post_id );
 	}
 
 	/**
-	 * Test delete revisions for a multiple post
+	 * Test thet post revisions can be deleted form multiple post
 	 */
-	public function test_delete_revisions_for_multiple_post() {
-		
-		$post_ids = $this->factory->post->create_many( 10, array(
-			'post_type' => 'post',
-		) );
+	public function test_that_post_revisions_can_be_deleted_from_multiple_post() {
 
-		foreach( $post_ids as $post_id ){
+		$post_ids = $this->factory->post->create_many(
+			10, array(
+				'post_type' => 'post',
+			)
+		);
+
+		foreach ( $post_ids as $post_id ) {
 
 			$revision_post = array(
 				'ID'           => $post_id,
@@ -85,14 +88,16 @@ class DeletePostsByRevisionModuleTest extends WPCoreUnitTestCase {
 		}
 
 		$delete_options = array(
-			'revisions'    => 'revisions',
-			'limit_to'     => -1,
-			'restrict'     => false,
-			'force_delete' => false,
+			'revisions' => 'revisions',
 		);
 
 		$posts_deleted = $this->module->delete( $delete_options );
 		$this->assertEquals( 10, $posts_deleted );
+
+		foreach ( $post_ids as $post_id ) {
+			$post = get_post( $post_id );
+			$this->assertEquals( $post->ID, $post_id );
+		}
 
 	}
 

--- a/tests/wp-unit/include/Core/Terms/Modules/DeleteTermsByNameModuleTest.php
+++ b/tests/wp-unit/include/Core/Terms/Modules/DeleteTermsByNameModuleTest.php
@@ -43,6 +43,7 @@ class DeleteTermsByNameModuleTest extends WPCoreUnitTestCase {
 						'Term A',
 						'Term B',
 						'Term C',
+						'term A',
 					),
 				),
 				array(
@@ -53,6 +54,7 @@ class DeleteTermsByNameModuleTest extends WPCoreUnitTestCase {
 				array(
 					'Term B',
 					'Term C',
+					'term A',
 				),
 			),
 			array(
@@ -73,6 +75,26 @@ class DeleteTermsByNameModuleTest extends WPCoreUnitTestCase {
 				array(
 					'Term A',
 					'Term B',
+					'Term C',
+				),
+			),
+			array(
+				array(
+					'post_type' => 'post',
+					'taxonomy'  => 'custom_taxonomy',
+					'terms'     => array(
+						'Term A',
+						'Term sample B',
+						'Term C',
+					),
+				),
+				array(
+					'search_term' => 'Term sample B',
+					'operator'    => 'equal_to',
+				),
+				1,
+				array(
+					'Term A',
 					'Term C',
 				),
 			),
@@ -163,6 +185,27 @@ class DeleteTermsByNameModuleTest extends WPCoreUnitTestCase {
 				3,
 				array(),
 			),
+			array(
+				array(
+					'post_type' => 'post',
+					'taxonomy'  => 'custom_taxonomy',
+					'terms'     => array(
+						'Term A',
+						'Term sample B',
+						'Term Sample C',
+					),
+				),
+				array(
+					'search_term' => 'Term sample',
+					'operator'    => 'not_equal_to',
+				),
+				0,
+				array(
+					'Term A',
+					'Term sample B',
+					'Term Sample C',
+				),
+			),
 		);
 	}
 
@@ -215,6 +258,25 @@ class DeleteTermsByNameModuleTest extends WPCoreUnitTestCase {
 					'Term A',
 					'sample Term B',
 					'Term C',
+				),
+			),
+			array(
+				array(
+					'post_type' => 'post',
+					'taxonomy'  => 'custom_taxonomy',
+					'terms'     => array(
+						'Term A',
+						'Term Sample B',
+						'Term Sample C',
+					),
+				),
+				array(
+					'search_term' => 'Term Sample',
+					'operator'    => 'starts_with',
+				),
+				2,
+				array(
+					'Term A',
 				),
 			),
 			array(
@@ -311,6 +373,27 @@ class DeleteTermsByNameModuleTest extends WPCoreUnitTestCase {
 					'Term C Sample',
 				),
 			),
+			array(
+				array(
+					'post_type' => 'post',
+					'taxonomy'  => 'custom_taxonomy',
+					'terms'     => array(
+						'sample Term A',
+						'Term B sample',
+						'Term C Sample',
+					),
+				),
+				array(
+					'search_term' => 'Term',
+					'operator'    => 'ends_with',
+				),
+				0,
+				array(
+					'sample Term A',
+					'Term B sample',
+					'Term C Sample',
+				),
+			),
 		);
 	}
 
@@ -329,7 +412,7 @@ class DeleteTermsByNameModuleTest extends WPCoreUnitTestCase {
 					'taxonomy'  => 'post_tag',
 					'terms'     => array(
 						'Term A',
-						'Term B',
+						'Term Sample B',
 						'Term C Sample',
 					),
 				),
@@ -337,10 +420,9 @@ class DeleteTermsByNameModuleTest extends WPCoreUnitTestCase {
 					'search_term' => 'Sample',
 					'operator'    => 'contains',
 				),
-				1,
+				2,
 				array(
 					'Term A',
-					'Term B',
 				),
 			),
 			array(
@@ -349,7 +431,7 @@ class DeleteTermsByNameModuleTest extends WPCoreUnitTestCase {
 					'taxonomy'  => 'link_category',
 					'terms'     => array(
 						'Term A',
-						'Term Sample B',
+						'Term B',
 						'Term C sample',
 					),
 				),
@@ -357,9 +439,10 @@ class DeleteTermsByNameModuleTest extends WPCoreUnitTestCase {
 					'search_term' => 'Sample',
 					'operator'    => 'contains',
 				),
-				1,
+				0,
 				array(
 					'Term A',
+					'Term B',
 					'Term C sample',
 				),
 			),
@@ -380,6 +463,27 @@ class DeleteTermsByNameModuleTest extends WPCoreUnitTestCase {
 				1,
 				array(
 					'Term A',
+					'Term C Sample',
+				),
+			),
+			array(
+				array(
+					'post_type' => 'post',
+					'taxonomy'  => 'custom_taxonomy',
+					'terms'     => array(
+						'Term A',
+						'Term B',
+						'Term C Sample',
+					),
+				),
+				array(
+					'search_term' => 'sample',
+					'operator'    => 'contains',
+				),
+				0,
+				array(
+					'Term A',
+					'Term B',
 					'Term C Sample',
 				),
 			),
@@ -451,6 +555,27 @@ class DeleteTermsByNameModuleTest extends WPCoreUnitTestCase {
 				),
 				2,
 				array(
+					'Term C Sample',
+				),
+			),
+			array(
+				array(
+					'post_type' => 'post',
+					'taxonomy'  => 'custom_taxonomy',
+					'terms'     => array(
+						'Sample Term A',
+						'Term Sample B',
+						'Term C Sample',
+					),
+				),
+				array(
+					'search_term' => 'Sample',
+					'operator'    => 'not_contains',
+				),
+				0,
+				array(
+					'Sample Term A',
+					'Term Sample B',
 					'Term C Sample',
 				),
 			),

--- a/tests/wp-unit/include/Core/Terms/Modules/DeleteTermsByNameModuleTest.php
+++ b/tests/wp-unit/include/Core/Terms/Modules/DeleteTermsByNameModuleTest.php
@@ -101,9 +101,371 @@ class DeleteTermsByNameModuleTest extends WPCoreUnitTestCase {
 	}
 
 	/**
+	 * Data provider to test `test_that_terms_can_be_deleted_by_name_using_various_filters` method.
+	 *
+	 * @see DeleteTermsByNameModuleTest::test_that_terms_can_be_deleted_by_name_using_various_filters() To see how the data is used.
+	 *
+	 * @return array Data.
+	 */
+	public function provide_data_to_test_deletion_of_terms_with_not_equals_operator() {
+		return array(
+			array(
+				array(
+					'post_type' => 'post',
+					'taxonomy'  => 'post_tag',
+					'terms'     => array(
+						'Term A',
+						'Term B',
+						'Term C',
+						'term A',
+					),
+				),
+				array(
+					'search_term' => 'Term A',
+					'operator'    => 'not_equal_to',
+				),
+				3,
+				array(
+					'Term A',
+				),
+			),
+			array(
+				array(
+					'post_type' => 'post',
+					'taxonomy'  => 'category',
+					'terms'     => array(
+						'Term A',
+						'Term B',
+						'Term C',
+					),
+				),
+				array(
+					'search_term' => 'Term',
+					'operator'    => 'not_equal_to',
+				),
+				3,
+				array(),
+			),
+			array(
+				array(
+					'post_type' => 'post',
+					'taxonomy'  => 'custom_taxonomy',
+					'terms'     => array(
+						'Term A',
+						'Term sample B',
+						'Term Sample C',
+					),
+				),
+				array(
+					'search_term' => 'Term sample C',
+					'operator'    => 'not_equal_to',
+				),
+				3,
+				array(),
+			),
+		);
+	}
+
+	/**
+	 * Data provider to test `test_that_terms_can_be_deleted_by_name_using_various_filters` method.
+	 *
+	 * @see DeleteTermsByNameModuleTest::test_that_terms_can_be_deleted_by_name_using_various_filters() To see how the data is used.
+	 *
+	 * @return array Data.
+	 */
+	public function provide_data_to_test_deletion_of_terms_with_starts_with_operator() {
+		return array(
+			array(
+				array(
+					'post_type' => 'post',
+					'taxonomy'  => 'post_tag',
+					'terms'     => array(
+						'Term A',
+						'Term B',
+						'Another Term C',
+						'term D',
+					),
+				),
+				array(
+					'search_term' => 'Term',
+					'operator'    => 'starts_with',
+				),
+				2,
+				array(
+					'Another Term C',
+					'term D',
+				),
+			),
+			array(
+				array(
+					'post_type' => 'post',
+					'taxonomy'  => 'category',
+					'terms'     => array(
+						'Term A',
+						'sample Term B',
+						'Term C',
+					),
+				),
+				array(
+					'search_term' => 'Sample',
+					'operator'    => 'starts_with',
+				),
+				0,
+				array(
+					'Term A',
+					'sample Term B',
+					'Term C',
+				),
+			),
+			array(
+				array(
+					'post_type' => 'post',
+					'taxonomy'  => 'custom_taxonomy',
+					'terms'     => array(
+						'Term A',
+						'Term B',
+						'Term Sample C',
+					),
+				),
+				array(
+					'search_term' => 'Term sample',
+					'operator'    => 'starts_with',
+				),
+				0,
+				array(
+					'Term A',
+					'Term B',
+					'Term Sample C',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Data provider to test `test_that_terms_can_be_deleted_by_name_using_various_filters` method.
+	 *
+	 * @see DeleteTermsByNameModuleTest::test_that_terms_can_be_deleted_by_name_using_various_filters() To see how the data is used.
+	 *
+	 * @return array Data.
+	 */
+	public function provide_data_to_test_deletion_of_terms_with_ends_with_operator() {
+		return array(
+			array(
+				array(
+					'post_type' => 'post',
+					'taxonomy'  => 'post_tag',
+					'terms'     => array(
+						'Sample Term A',
+						'Term Sample B',
+						'Term C Sample',
+					),
+				),
+				array(
+					'search_term' => 'Sample',
+					'operator'    => 'ends_with',
+				),
+				1,
+				array(
+					'Sample Term A',
+					'Term Sample B',
+				),
+			),
+			array(
+				array(
+					'post_type' => 'post',
+					'taxonomy'  => 'category',
+					'terms'     => array(
+						'Sample Term A',
+						'Term Sample B',
+						'Term C sample',
+					),
+				),
+				array(
+					'search_term' => 'Sample',
+					'operator'    => 'ends_with',
+				),
+				0,
+				array(
+					'Sample Term A',
+					'Term Sample B',
+					'Term C sample',
+				),
+			),
+			array(
+				array(
+					'post_type' => 'post',
+					'taxonomy'  => 'custom_taxonomy',
+					'terms'     => array(
+						'sample Term A',
+						'Term B sample',
+						'Term C Sample',
+					),
+				),
+				array(
+					'search_term' => 'sample',
+					'operator'    => 'ends_with',
+				),
+				1,
+				array(
+					'sample Term A',
+					'Term C Sample',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Data provider to test `test_that_terms_can_be_deleted_by_name_using_various_filters` method.
+	 *
+	 * @see DeleteTermsByNameModuleTest::test_that_terms_can_be_deleted_by_name_using_various_filters() To see how the data is used.
+	 *
+	 * @return array Data.
+	 */
+	public function provide_data_to_test_deletion_of_terms_with_contains_operator() {
+		return array(
+			array(
+				array(
+					'post_type' => 'post',
+					'taxonomy'  => 'post_tag',
+					'terms'     => array(
+						'Term A',
+						'Term B',
+						'Term C Sample',
+					),
+				),
+				array(
+					'search_term' => 'Sample',
+					'operator'    => 'contains',
+				),
+				1,
+				array(
+					'Term A',
+					'Term B',
+				),
+			),
+			array(
+				array(
+					'post_type' => 'post',
+					'taxonomy'  => 'link_category',
+					'terms'     => array(
+						'Term A',
+						'Term Sample B',
+						'Term C sample',
+					),
+				),
+				array(
+					'search_term' => 'Sample',
+					'operator'    => 'contains',
+				),
+				1,
+				array(
+					'Term A',
+					'Term C sample',
+				),
+			),
+			array(
+				array(
+					'post_type' => 'post',
+					'taxonomy'  => 'custom_taxonomy',
+					'terms'     => array(
+						'Term A',
+						'Term sample B',
+						'Term C Sample',
+					),
+				),
+				array(
+					'search_term' => 'sample',
+					'operator'    => 'contains',
+				),
+				1,
+				array(
+					'Term A',
+					'Term C Sample',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Data provider to test `test_that_terms_can_be_deleted_by_name_using_various_filters` method.
+	 *
+	 * @see DeleteTermsByNameModuleTest::test_that_terms_can_be_deleted_by_name_using_various_filters() To see how the data is used.
+	 *
+	 * @return array Data.
+	 */
+	public function provide_data_to_test_deletion_of_terms_with_not_contains_operator() {
+		return array(
+			array(
+				array(
+					'post_type' => 'post',
+					'taxonomy'  => 'post_tag',
+					'terms'     => array(
+						'Term A',
+						'Term B',
+						'Term C Sample',
+					),
+				),
+				array(
+					'search_term' => 'Sample',
+					'operator'    => 'not_contains',
+				),
+				2,
+				array(
+					'Term C Sample',
+				),
+			),
+			array(
+				array(
+					'post_type' => 'post',
+					'taxonomy'  => 'nav_menu',
+					'terms'     => array(
+						'Term A Sample',
+						'Term Sample B',
+						'Sample Term C',
+					),
+				),
+				array(
+					'search_term' => 'Sample',
+					'operator'    => 'not_contains',
+				),
+				0,
+				array(
+					'Term A Sample',
+					'Term Sample B',
+					'Sample Term C',
+				),
+			),
+			array(
+				array(
+					'post_type' => 'post',
+					'taxonomy'  => 'custom_taxonomy',
+					'terms'     => array(
+						'Term A',
+						'Term sample B',
+						'Term C Sample',
+					),
+				),
+				array(
+					'search_term' => 'Sample',
+					'operator'    => 'not_contains',
+				),
+				2,
+				array(
+					'Term C Sample',
+				),
+			),
+		);
+	}
+
+	/**
 	 * Test deletion of terms by name.
 	 *
 	 * @dataProvider provide_data_to_test_deletion_of_terms_with_equals_operator
+	 * @dataProvider provide_data_to_test_deletion_of_terms_with_not_equals_operator
+	 * @dataProvider provide_data_to_test_deletion_of_terms_with_starts_with_operator
+	 * @dataProvider provide_data_to_test_deletion_of_terms_with_ends_with_operator
+	 * @dataProvider provide_data_to_test_deletion_of_terms_with_contains_operator
+	 * @dataProvider provide_data_to_test_deletion_of_terms_with_not_contains_operator
 	 *
 	 * @param array $inputs                           Inputs for test cases.
 	 * @param array $user_input                       Options selected by user.

--- a/tests/wp-unit/include/Core/Terms/Modules/DeleteTermsByNameModuleTest.php
+++ b/tests/wp-unit/include/Core/Terms/Modules/DeleteTermsByNameModuleTest.php
@@ -25,7 +25,6 @@ class DeleteTermsByNameModuleTest extends WPCoreUnitTestCase {
 		$this->module = new DeleteTermsByNameModule();
 	}
 
-
 	/**
 	 * Data provider to test `test_that_terms_can_be_deleted_by_name_using_various_filters` method.
 	 *
@@ -43,7 +42,6 @@ class DeleteTermsByNameModuleTest extends WPCoreUnitTestCase {
 						'Term A',
 						'Term B',
 						'Term C',
-						'term A',
 					),
 				),
 				array(
@@ -54,7 +52,6 @@ class DeleteTermsByNameModuleTest extends WPCoreUnitTestCase {
 				array(
 					'Term B',
 					'Term C',
-					'term A',
 				),
 			),
 			array(
@@ -139,14 +136,13 @@ class DeleteTermsByNameModuleTest extends WPCoreUnitTestCase {
 						'Term A',
 						'Term B',
 						'Term C',
-						'term A',
 					),
 				),
 				array(
 					'search_term' => 'Term A',
 					'operator'    => 'not_equal_to',
 				),
-				3,
+				2,
 				array(
 					'Term A',
 				),
@@ -179,10 +175,10 @@ class DeleteTermsByNameModuleTest extends WPCoreUnitTestCase {
 					),
 				),
 				array(
-					'search_term' => 'Term sample C',
+					'search_term' => 'Term Sample C',
 					'operator'    => 'not_equal_to',
 				),
-				3,
+				2,
 				array(),
 			),
 			array(
@@ -192,19 +188,15 @@ class DeleteTermsByNameModuleTest extends WPCoreUnitTestCase {
 					'terms'     => array(
 						'Term A',
 						'Term sample B',
-						'Term Sample C',
+						'Term sample C',
 					),
 				),
 				array(
 					'search_term' => 'Term sample',
 					'operator'    => 'not_equal_to',
 				),
-				0,
-				array(
-					'Term A',
-					'Term sample B',
-					'Term Sample C',
-				),
+				3,
+				array(),
 			),
 		);
 	}
@@ -226,7 +218,6 @@ class DeleteTermsByNameModuleTest extends WPCoreUnitTestCase {
 						'Term A',
 						'Term B',
 						'Another Term C',
-						'term D',
 					),
 				),
 				array(
@@ -236,7 +227,6 @@ class DeleteTermsByNameModuleTest extends WPCoreUnitTestCase {
 				2,
 				array(
 					'Another Term C',
-					'term D',
 				),
 			),
 			array(

--- a/tests/wp-unit/include/Core/Terms/Modules/DeleteTermsByNameModuleTest.php
+++ b/tests/wp-unit/include/Core/Terms/Modules/DeleteTermsByNameModuleTest.php
@@ -25,10 +25,15 @@ class DeleteTermsByNameModuleTest extends WPCoreUnitTestCase {
 		$this->module = new DeleteTermsByNameModule();
 	}
 
+
 	/**
-	 * Provide data to test deletion of terms by name.
+	 * Data provider to test `test_that_terms_can_be_deleted_by_name_using_various_filters` method.
+	 *
+	 * @see DeleteTermsByNameModuleTest::test_that_terms_can_be_deleted_by_name_using_various_filters() To see how the data is used.
+	 *
+	 * @return array Data.
 	 */
-	public function provide_data_to_test_that_terms_can_be_deleted_by_name() {
+	public function provide_data_to_test_deletion_of_terms_with_equals_operator() {
 		return array(
 			array(
 				array(
@@ -53,85 +58,7 @@ class DeleteTermsByNameModuleTest extends WPCoreUnitTestCase {
 			array(
 				array(
 					'post_type' => 'post',
-					'taxonomy'  => 'post_tag',
-					'terms'     => array(
-						'Term A',
-						'Term B',
-						'Term C',
-					),
-				),
-				array(
-					'search_term' => 'Term A',
-					'operator'    => 'not_equal_to',
-				),
-				2,
-				array(
-					'Term A',
-				),
-			),
-			array(
-				array(
-					'post_type' => 'post',
-					'taxonomy'  => 'post_tag',
-					'terms'     => array(
-						'Term A',
-						'Term B',
-						'Another Term C',
-					),
-				),
-				array(
-					'search_term' => 'Term',
-					'operator'    => 'starts_with',
-				),
-				2,
-				array(
-					'Another Term C',
-				),
-			),
-			array(
-				array(
-					'post_type' => 'post',
-					'taxonomy'  => 'post_tag',
-					'terms'     => array(
-						'Term A',
-						'Term B',
-						'Term C',
-					),
-				),
-				array(
-					'search_term' => 'Another',
-					'operator'    => 'starts_with',
-				),
-				0,
-				array(
-					'Term A',
-					'Term B',
-					'Term C',
-				),
-			),
-			array(
-				array(
-					'post_type' => 'post',
-					'taxonomy'  => 'post_tag',
-					'terms'     => array(
-						'A Term',
-						'B Term',
-						'Term C',
-					),
-				),
-				array(
-					'search_term' => 'Term',
-					'operator'    => 'ends_with',
-				),
-				2,
-				array(
-					'Term C',
-				),
-			),
-			array(
-				array(
-					'post_type' => 'post',
-					'taxonomy'  => 'post_tag',
+					'taxonomy'  => 'category',
 					'terms'     => array(
 						'Term A',
 						'Term B',
@@ -140,7 +67,7 @@ class DeleteTermsByNameModuleTest extends WPCoreUnitTestCase {
 				),
 				array(
 					'search_term' => 'Term',
-					'operator'    => 'ends_with',
+					'operator'    => 'equal_to',
 				),
 				0,
 				array(
@@ -148,83 +75,6 @@ class DeleteTermsByNameModuleTest extends WPCoreUnitTestCase {
 					'Term B',
 					'Term C',
 				),
-			),
-			array(
-				array(
-					'post_type' => 'post',
-					'taxonomy'  => 'post_tag',
-					'terms'     => array(
-						'Term sample A',
-						'Term sample B',
-						'Term C',
-					),
-				),
-				array(
-					'search_term' => 'sample',
-					'operator'    => 'contains',
-				),
-				2,
-				array(
-					'Term C',
-				),
-			),
-			array(
-				array(
-					'post_type' => 'post',
-					'taxonomy'  => 'post_tag',
-					'terms'     => array(
-						'Term A',
-						'Term B',
-						'Term C',
-					),
-				),
-				array(
-					'search_term' => 'sample',
-					'operator'    => 'contains',
-				),
-				0,
-				array(
-					'Term A',
-					'Term B',
-					'Term C',
-				),
-			),
-			array(
-				array(
-					'post_type' => 'post',
-					'taxonomy'  => 'post_tag',
-					'terms'     => array(
-						'Term sample A',
-						'Term sample B',
-						'Term C',
-					),
-				),
-				array(
-					'search_term' => 'sample',
-					'operator'    => 'not_contains',
-				),
-				1,
-				array(
-					'Term sample A',
-					'Term sample B',
-				),
-			),
-			array(
-				array(
-					'post_type' => 'post',
-					'taxonomy'  => 'post_tag',
-					'terms'     => array(
-						'Term A',
-						'Term B',
-						'Term C',
-					),
-				),
-				array(
-					'search_term' => 'sample',
-					'operator'    => 'not_contains',
-				),
-				3,
-				array(),
 			),
 			array(
 				array(
@@ -238,11 +88,13 @@ class DeleteTermsByNameModuleTest extends WPCoreUnitTestCase {
 				),
 				array(
 					'search_term' => 'sample',
-					'operator'    => 'not_contains',
+					'operator'    => 'equal_to',
 				),
-				2,
+				0,
 				array(
-					'term_not_deleted' => 'Term sample B',
+					'Term A',
+					'Term sample B',
+					'Term C',
 				),
 			),
 		);
@@ -251,7 +103,7 @@ class DeleteTermsByNameModuleTest extends WPCoreUnitTestCase {
 	/**
 	 * Test deletion of terms by name.
 	 *
-	 * @dataProvider provide_data_to_test_that_terms_can_be_deleted_by_name
+	 * @dataProvider provide_data_to_test_deletion_of_terms_with_equals_operator
 	 *
 	 * @param array $inputs                           Inputs for test cases.
 	 * @param array $user_input                       Options selected by user.


### PR DESCRIPTION
Split data provider in multiple functions and add missing variants for delete terms by name

Blocked by #497 
Fix #478 