### PR TITLE
PR: Use post type with status dropdown for all meta fields #615

### DIFF
--- a/include/Core/Base/Mixin/Fetcher.php
+++ b/include/Core/Base/Mixin/Fetcher.php
@@ -60,7 +60,7 @@ abstract class Fetcher {
 				}
 
 				$post_type_key               = $post_type->labels->singular_name . ' (' . $post_type_name . ')';
-				$post_type_with_status_key   = $post_type_name . '-' . $post_status_name;
+				$post_type_with_status_key   = $post_type_name . '|' . $post_status_name;
 				$post_type_with_status_label = $post_status->label . ' (' . $count_posts->{$post_status_name} . ' ' . __( 'Posts', 'bulk-delete' ) . ')';
 
 				$post_types_by_status[ $post_type_key ][ $post_type_with_status_key ] = $post_type_with_status_label;

--- a/include/Core/Base/Mixin/Renderer.php
+++ b/include/Core/Base/Mixin/Renderer.php
@@ -124,7 +124,11 @@ abstract class Renderer extends Fetcher {
 	protected function split_post_type_and_status( $str ) {
 		$type_status = array();
 
-		$str_arr = explode( '-', $str );
+		if ( strpos( $str, '|' ) === false ) {
+			$str_arr = explode( '-', $str );
+		} else {
+			$str_arr = explode( '|', $str );
+		}
 
 		if ( count( $str_arr ) > 1 ) {
 			$type_status['status'] = end( $str_arr );

--- a/include/Core/Metas/Modules/DeleteCommentMetaModule.php
+++ b/include/Core/Metas/Modules/DeleteCommentMetaModule.php
@@ -42,7 +42,7 @@ class DeleteCommentMetaModule extends MetasModule {
 		<fieldset class="options">
 			<h4><?php _e( 'Select the post type whose comment meta fields you want to delete', 'bulk-delete' ); ?></h4>
 			<table class="optiontable">
-				<?php $this->render_post_type_dropdown(); ?>
+				<?php $this->render_post_type_with_status( false ); ?>
 			</table>
 
 			<h4><?php _e( 'Choose your comment meta field settings', 'bulk-delete' ); ?></h4>
@@ -100,7 +100,7 @@ class DeleteCommentMetaModule extends MetasModule {
 	}
 
 	protected function convert_user_input_to_options( $request, $options ) {
-		$options['post_type'] = esc_sql( bd_array_get( $request, 'smbd_' . $this->field_slug . '_post_type', 'post' ) );
+		$options['post_type'] = esc_sql( bd_array_get( $request, 'smbd_' . $this->field_slug ) );
 
 		$options['use_value'] = bd_array_get_bool( $request, 'smbd_' . $this->field_slug . '_use_value', false );
 		$options['meta_key']  = esc_sql( bd_array_get( $request, 'smbd_' . $this->field_slug . '_meta_key', '' ) );
@@ -116,8 +116,10 @@ class DeleteCommentMetaModule extends MetasModule {
 	}
 
 	protected function do_delete( $options ) {
-		$args = array(
-			'post_type' => $options['post_type'],
+		$type_status = $this->split_post_type_and_status( $options['post_type'] );
+		$args        = array(
+			'post_type'   => $type_status['type'],
+			'post_status' => $type_status['status'],
 		);
 
 		if ( $options['limit_to'] > 0 ) {

--- a/include/Core/Metas/Modules/DeletePostMetaModule.php
+++ b/include/Core/Metas/Modules/DeletePostMetaModule.php
@@ -36,7 +36,7 @@ class DeletePostMetaModule extends MetasModule {
 			<h4><?php _e( 'Select the post type whose post meta fields you want to delete', 'bulk-delete' ); ?></h4>
 
 			<table class="optiontable">
-				<?php $this->render_post_type_dropdown(); ?>
+				<?php $this->render_post_type_with_status( false ); ?>
 			</table>
 
 			<h4><?php _e( 'Choose your post meta field settings', 'bulk-delete' ); ?></h4>
@@ -112,7 +112,7 @@ class DeletePostMetaModule extends MetasModule {
 	}
 
 	protected function convert_user_input_to_options( $request, $options ) {
-		$options['post_type'] = esc_sql( bd_array_get( $request, 'smbd_' . $this->field_slug . '_post_type', 'post' ) );
+		$options['post_type'] = esc_sql( bd_array_get( $request, 'smbd_' . $this->field_slug ) );
 
 		$options['use_value'] = bd_array_get( $request, 'smbd_' . $this->field_slug . '_use_value', 'use_key' );
 		$options['meta_key']  = esc_sql( bd_array_get( $request, 'smbd_' . $this->field_slug . '_key', '' ) );
@@ -128,9 +128,11 @@ class DeletePostMetaModule extends MetasModule {
 	}
 
 	protected function do_delete( $options ) {
-		$count = 0;
-		$args  = array(
-			'post_type' => $options['post_type'],
+		$count       = 0;
+		$type_status = $this->split_post_type_and_status( $options['post_type'] );
+		$args        = array(
+			'post_type'   => $type_status['type'],
+			'post_status' => $type_status['status'],
 		);
 
 		if ( $options['limit_to'] > 0 ) {

--- a/tests/wp-unit/include/Core/Metas/Modules/DeleteCommentMetaModuleTest.php
+++ b/tests/wp-unit/include/Core/Metas/Modules/DeleteCommentMetaModuleTest.php
@@ -651,7 +651,7 @@ class DeleteCommentMetaModuleTest extends WPCoreUnitTestCase {
 					'limit_to'  => 0,
 					'restrict'  => false,
 					'date_op'   => '',
-					'days'      => '',
+					'days'      => 0,
 				),
 				array(
 					'number_of_comment_metas_deleted' => 5,
@@ -682,7 +682,7 @@ class DeleteCommentMetaModuleTest extends WPCoreUnitTestCase {
 					'limit_to'  => 0,
 					'restrict'  => false,
 					'date_op'   => '',
-					'days'      => '',
+					'days'      => 0,
 				),
 				array(
 					'number_of_comment_metas_deleted' => 3,

--- a/tests/wp-unit/include/Core/Metas/Modules/DeleteCommentMetaModuleTest.php
+++ b/tests/wp-unit/include/Core/Metas/Modules/DeleteCommentMetaModuleTest.php
@@ -619,4 +619,119 @@ class DeleteCommentMetaModuleTest extends WPCoreUnitTestCase {
 
 		$this->assertEquals( $total_comments / 2, $metas_deleted );
 	}
+
+	/**
+	 * Provide data to test deletion of comment meta with custom post status.
+	 *
+	 * @return array Data.
+	 */
+	public function provide_data_to_test_comment_meta_deletion_with_custom_post_status() {
+		return array(
+			// (+ve) case: Built-in post type and custom post status.
+			array(
+				array(
+					'post_type'   => 'post',
+					'post_status' => 'wc-completed',
+					'no_of_posts' => 5,
+					'metas'       => array(
+						array(
+							'key'   => 'test_key',
+							'value' => 'Matched Value',
+						),
+						array(
+							'key'   => 'another_key',
+							'value' => 'Another Value',
+						),
+					),
+				),
+				array(
+					'meta_key'  => 'test_key',
+					'post_type' => 'post|wc-completed',
+					'use_value' => false,
+					'limit_to'  => 0,
+					'restrict'  => false,
+					'date_op'   => '',
+					'days'      => '',
+				),
+				array(
+					'number_of_comment_metas_deleted' => 5,
+					'left_over_comment_meta'          => 'another_key',
+				),
+			),
+			// (+ve) case: Custom post type and custom post status.
+			array(
+				array(
+					'post_type'   => 'product',
+					'post_status' => 'wc-completed',
+					'no_of_posts' => 3,
+					'metas'       => array(
+						array(
+							'key'   => 'test_key',
+							'value' => 'Matched Value',
+						),
+						array(
+							'key'   => 'another_key',
+							'value' => 'Another Value',
+						),
+					),
+				),
+				array(
+					'meta_key'  => 'test_key',
+					'post_type' => 'product|wc-completed',
+					'use_value' => false,
+					'limit_to'  => 0,
+					'restrict'  => false,
+					'date_op'   => '',
+					'days'      => '',
+				),
+				array(
+					'number_of_comment_metas_deleted' => 3,
+					'left_over_comment_meta'          => 'another_key',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Test deletion of comment meta with custom post status.
+	 *
+	 * @param array $setup     create posts, comments and meta params.
+	 * @param array $operation Possible operations.
+	 * @param array $expected  expected output.
+	 *
+	 * @dataProvider provide_data_to_test_comment_meta_deletion_with_custom_post_status
+	 */
+	public function test_comment_meta_deletion_with_custom_post_status( $setup, $operation, $expected ) {
+		$this->register_post_type( $setup['post_type'] );
+		register_post_status( $setup['post_status'] );
+		$metas = $setup['metas'];
+
+		// Create posts.
+		$post_ids = $this->factory->post->create_many(
+			$setup['no_of_posts'],
+			array(
+				'post_type'   => $setup['post_type'],
+				'post_status' => $setup['post_status'],
+			)
+		);
+
+		foreach ( $post_ids as $post_id ) {
+			$comment_data = array(
+				'comment_post_ID' => $post_id,
+				'comment_content' => 'Test Comment',
+			);
+			$comment_id   = $this->factory->comment->create( $comment_data );
+			foreach ( $metas as $meta ) {
+				add_comment_meta( $comment_id, $meta['key'], $meta['value'] );
+			}
+		}
+
+		$delete_options = $operation;
+
+		$comment_metas_deleted = $this->module->delete( $delete_options );
+		$this->assertEquals( $expected['number_of_comment_metas_deleted'], $comment_metas_deleted );
+
+		$this->assertTrue( metadata_exists( 'comment', $comment_id, $expected['left_over_comment_meta'] ) );
+		$this->assertFalse( metadata_exists( 'comment', $comment_id, $operation['meta_key'] ) );
+	}
 }

--- a/tests/wp-unit/include/Core/Metas/Modules/DeletePostMetaModuleTest.php
+++ b/tests/wp-unit/include/Core/Metas/Modules/DeletePostMetaModuleTest.php
@@ -101,10 +101,6 @@ class DeletePostMetaModuleTest extends WPCoreUnitTestCase {
 	/**
 	 * Test deletion of post meta with custom post status.
 	 *
-	 * TODO: This test is currently skipped because duplicate meta keys is not fully supported yet.
-	 *
-	 * @see https://github.com/sudar/bulk-delete/issues/515 for details.
-	 *
 	 * @param array $setup     create posts and meta params.
 	 * @param array $operation Possible operations.
 	 * @param array $expected  expected output.

--- a/tests/wp-unit/include/Core/Metas/Modules/DeletePostMetaModuleTest.php
+++ b/tests/wp-unit/include/Core/Metas/Modules/DeletePostMetaModuleTest.php
@@ -5,11 +5,11 @@ namespace BulkWP\BulkDelete\Core\Metas\Modules;
 use BulkWP\Tests\WPCore\WPCoreUnitTestCase;
 
 /**
- * Test Delete Post Meta Module.
+ * Test Deletion of Post Meta.
  *
  * Tests \BulkWP\BulkDelete\Core\Metas\Modules\DeletePostMetaModule
  *
- * @since 6.0.0
+ * @since 6.0.1
  */
 class DeletePostMetaModuleTest extends WPCoreUnitTestCase {
 	/**
@@ -19,6 +19,9 @@ class DeletePostMetaModuleTest extends WPCoreUnitTestCase {
 	 */
 	protected $module;
 
+	/**
+	 * Setup the test case.
+	 */
 	public function setUp() {
 		parent::setUp();
 
@@ -26,227 +29,116 @@ class DeletePostMetaModuleTest extends WPCoreUnitTestCase {
 	}
 
 	/**
-	 * Add to test single post meta from the default post type.
+	 * Provide data to test deletion of post meta with custom post status.
+	 *
+	 * @return array Data.
 	 */
-	public function test_that_single_post_meta_can_be_deleted_from_default_post_type() {
-		// Create a post
-		$post = $this->factory->post->create( array( 'post_title' => 'Test Post' ) );
-
-		// Assign meta value to the post
-		add_post_meta( $post, 'time', '10/10/2018' );
-
-		$post_meta = get_post_meta( $post, 'time' );
-
-		// Assert that post meta have posts
-		$this->assertEquals( 1, count( $post_meta ) );
-
-		// call our method.
-		$delete_options = array(
-			'post_type'    => 'post',
-			'limit_to'     => -1,
-			'restrict'     => false,
-			'force_delete' => false,
-			'use_value'    => 'use_key',
-			'meta_key'     => 'time',
-			'date_op'      => '',
-			'days'         => '',
+	public function provide_data_to_test_post_meta_deletion_with_custom_post_status() {
+		return array(
+			// (+ve) case: Built-in post type and custom post status.
+			array(
+				array(
+					'post_type'   => 'post',
+					'post_status' => 'wc-completed',
+					'no_of_posts' => 10,
+					'metas'       => array(
+						array(
+							'key'   => 'test_key',
+							'value' => 'Matched Value',
+						),
+						array(
+							'key'   => 'another_key',
+							'value' => 'Another Value',
+						),
+					),
+				),
+				array(
+					'meta_key'  => 'test_key',
+					'post_type' => 'post|wc-completed',
+					'use_value' => 'use_key',
+					'limit_to'  => 0,
+					'restrict'  => false,
+					'date_op'   => '',
+					'days'      => '',
+				),
+				array(
+					'number_of_post_metas_deleted' => 10,
+					'left_over_meta_data'          => 'another_key',
+				),
+			),
+			// (+ve) case: Custom post type and custom post status.
+			array(
+				array(
+					'post_type'   => 'product',
+					'post_status' => 'wc-completed',
+					'no_of_posts' => 5,
+					'metas'       => array(
+						array(
+							'key'   => 'test_key',
+							'value' => 'Matched Value',
+						),
+						array(
+							'key'   => 'another_key',
+							'value' => 'Another Value',
+						),
+					),
+				),
+				array(
+					'meta_key'  => 'test_key',
+					'post_type' => 'product|wc-completed',
+					'use_value' => 'use_key',
+					'limit_to'  => 0,
+					'restrict'  => false,
+				),
+				array(
+					'number_of_post_metas_deleted' => 5,
+					'left_over_meta_data'          => 'another_key',
+				),
+			),
 		);
-
-		$meta_deleted = $this->module->delete( $delete_options );
-
-		$post_meta = get_post_meta( $post, 'time' );
-
-		// Assert that post meta does not have posts
-		$this->assertEquals( 0, count( $post_meta ) );
 	}
 
 	/**
-	 * Add to test more than one post meta from the default post type.
+	 * Test deletion of post meta with custom post status.
+	 *
+	 * TODO: This test is currently skipped because duplicate meta keys is not fully supported yet.
+	 *
+	 * @see https://github.com/sudar/bulk-delete/issues/515 for details.
+	 *
+	 * @param array $setup     create posts and meta params.
+	 * @param array $operation Possible operations.
+	 * @param array $expected  expected output.
+	 *
+	 * @dataProvider provide_data_to_test_post_meta_deletion_with_custom_post_status
 	 */
-	public function test_that_more_than_one_post_meta_can_be_deleted_from_default_post_type() {
-		// Create a post
-		$post = $this->factory->post->create( array( 'post_title' => 'Test Post' ) );
+	public function test_post_meta_deletion_with_custom_post_status( $setup, $operation, $expected ) {
+		$this->register_post_type( $setup['post_type'] );
+		register_post_status( $setup['post_status'] );
+		$metas = $setup['metas'];
 
-		// Assign meta value to the post
-		add_post_meta( $post, 'time', '10/10/2018' );
-		add_post_meta( $post, 'time', '11/11/2018' );
-		add_post_meta( $post, 'time', '12/12/2018' );
-
-		$post_meta = get_post_meta( $post, 'time' );
-		$this->assertEquals( 3, count( $post_meta ) );
-
-		// call our method.
-		$delete_options = array(
-			'post_type'    => 'post',
-			'limit_to'     => -1,
-			'restrict'     => false,
-			'force_delete' => false,
-			'use_value'    => 'use_key',
-			'meta_key'     => 'time',
-			'date_op'      => '',
-			'days'         => '',
+		// Create posts.
+		$post_ids = $this->factory->post->create_many(
+			$setup['no_of_posts'],
+			array(
+				'post_type'   => $setup['post_type'],
+				'post_status' => $setup['post_status'],
+			)
 		);
 
-		$meta_deleted = $this->module->delete( $delete_options );
-
-		$post_meta = get_post_meta( $post, 'time' );
-		$this->assertEquals( 0, count( $post_meta ) );
-	}
-
-	/**
-	 * Add to test single post meta from the custom post type.
-	 */
-	public function test_that_single_post_meta_can_be_deleted_from_custom_post_type() {
-		// Create a post with custom post type
-		$post = $this->factory->post->create( array( 'post_title' => 'Test Post', 'post_type' => 'custom' ) );
-
-		// Assign meta value to the post
-		add_post_meta( $post, 'time', '10/10/2018' );
-
-		$post_meta = get_post_meta( $post, 'time' );
-		$this->assertEquals( 1, count( $post_meta ) );
-
-		// call our method.
-		$delete_options = array(
-			'post_type'    => 'custom',
-			'limit_to'     => -1,
-			'restrict'     => false,
-			'force_delete' => false,
-			'use_value'    => 'use_key',
-			'meta_key'     => 'time',
-			'date_op'      => '',
-			'days'         => '',
-		);
-
-		$meta_deleted = $this->module->delete( $delete_options );
-
-		$post_meta = get_post_meta( $post, 'time' );
-		$this->assertEquals( 0, count( $post_meta ) );
-	}
-
-	/**
-	 * Add to test more than one post meta from the custom post type.
-	 */
-	public function test_that_more_than_one_post_meta_can_de_deleted_from_custom_post_type() {
-		// Create a post with custom post type
-		$post = $this->factory->post->create( array( 'post_title' => 'Test Post', 'post_type' => 'custom' ) );
-
-		// Assign meta value to the post
-		add_post_meta( $post, 'time', '10/10/2018' );
-		add_post_meta( $post, 'time', '11/11/2018' );
-		add_post_meta( $post, 'time', '12/12/2018' );
-
-		$post_meta = get_post_meta( $post, 'time' );
-		$this->assertEquals( 3, count( $post_meta ) );
-
-		// call our method.
-		$delete_options = array(
-			'post_type'    => 'custom',
-			'limit_to'     => -1,
-			'restrict'     => false,
-			'force_delete' => false,
-			'use_value'    => 'use_key',
-			'meta_key'     => 'time',
-			'date_op'      => '',
-			'days'         => '',
-		);
-
-		$meta_deleted = $this->module->delete( $delete_options );
-
-		$post_meta = get_post_meta( $post, 'time' );
-		$this->assertEquals( 0, count( $post_meta ) );
-	}
-
-	/**
-	 * Add to test post meta delete from post published date.
-	 */
-	public function test_that_post_meta_deletion_be_restricted_by_post_older_than() {
-		// Create a post with past date
-		$date = date( 'Y-m-d H:i:s', strtotime( '-5 day' ) );
-		$post = $this->factory->post->create( array( 'post_title' => 'Test Post', 'post_date' => $date ) );
-
-		// Assign meta value to the post
-		add_post_meta( $post, 'time', '10/10/2018' );
-
-		$post_meta = get_post_meta( $post, 'time' );
-		$this->assertEquals( 1, count( $post_meta ) );
-
-		// call our method.
-		$delete_options = array(
-			'post_type'    => 'post',
-			'limit_to'     => -1,
-			'restrict'     => false,
-			'force_delete' => false,
-			'use_value'    => 'use_key',
-			'meta_key'     => 'time',
-			'date_op'      => 'before',
-			'days'         => '3',
-		);
-
-		$meta_deleted = $this->module->delete( $delete_options );
-
-		$post_meta = get_post_meta( $post, 'time' );
-		$this->assertEquals( 0, count( $post_meta ) );
-	}
-
-	/**
-	 * Add to test post meta delete from previous published with in x date.
-	 */
-	public function test_that_post_meta_deletion_be_restricted_by_posts_within_the_last_x_days() {
-		// Create a post with past date
-		$date = date( 'Y-m-d H:i:s', strtotime( '-3 day' ) );
-		$post = $this->factory->post->create( array( 'post_title' => 'Test Post', 'post_date' => $date ) );
-
-		// Assign meta value to the post
-		add_post_meta( $post, 'time', '10/10/2018' );
-
-		$post_meta = get_post_meta( $post, 'time' );
-		$this->assertEquals( 1, count( $post_meta ) );
-
-		// call our method.
-		$delete_options = array(
-			'post_type'    => 'post',
-			'limit_to'     => -1,
-			'restrict'     => false,
-			'force_delete' => false,
-			'use_value'    => 'use_key',
-			'meta_key'     => 'time',
-			'date_op'      => 'after',
-			'days'         => '5',
-		);
-
-		$meta_deleted = $this->module->delete( $delete_options );
-
-		$post_meta = get_post_meta( $post, 'time' );
-		$this->assertEquals( 0, count( $post_meta ) );
-	}
-
-	/**
-	 * Add to test delete post meta in batches.
-	 */
-	public function test_that_post_meta_can_be_deleted_in_batches() {
-		$posts = $this->factory->post->create_many( 20, array(
-			'post_type'   => 'post',
-		) );
-		foreach($posts as $post ){
-			// Assign meta value to the post
-			add_post_meta( $post, 'time', '10/10/2018' );
+		foreach ( $post_ids as $post_id ) {
+			foreach ( $metas as $meta ) {
+				add_post_meta( $post_id, $meta['key'], $meta['value'] );
+			}
 		}
 
-		// call our method.
-		$delete_options = array(
-			'post_type'    => 'post',
-			'limit_to'     => 10,
-			'restrict'     => false,
-			'force_delete' => false,
-			'use_value'    => 'use_key',
-			'meta_key'     => 'time',
-			'date_op'      => '',
-			'days'         => '',
-		);
+		$delete_options = $operation;
 
-		$meta_deleted = $this->module->delete( $delete_options );
+		$post_metas_deleted = $this->module->delete( $delete_options );
+		$this->assertEquals( $expected['number_of_post_metas_deleted'], $post_metas_deleted );
 
-		$this->assertEquals( 10, $meta_deleted );
+		foreach ( $post_ids as $post_id ) {
+			$this->assertTrue( metadata_exists( 'post', $post_id, $expected['left_over_meta_data'] ) );
+			$this->assertFalse( metadata_exists( 'post', $post_id, $operation['meta_key'] ) );
+		}
 	}
 }

--- a/tests/wp-unit/include/Core/Metas/Modules/DeletePostMetaModuleTest.php
+++ b/tests/wp-unit/include/Core/Metas/Modules/DeletePostMetaModuleTest.php
@@ -59,7 +59,7 @@ class DeletePostMetaModuleTest extends WPCoreUnitTestCase {
 					'limit_to'  => 0,
 					'restrict'  => false,
 					'date_op'   => '',
-					'days'      => '',
+					'days'      => 0,
 				),
 				array(
 					'number_of_post_metas_deleted' => 10,
@@ -89,6 +89,8 @@ class DeletePostMetaModuleTest extends WPCoreUnitTestCase {
 					'use_value' => 'use_key',
 					'limit_to'  => 0,
 					'restrict'  => false,
+					'date_op'   => '',
+					'days'      => 0,
 				),
 				array(
 					'number_of_post_metas_deleted' => 5,

--- a/tests/wp-unit/include/Core/Metas/Modules/DeletePostMetaModuleTestInOldFormat.php
+++ b/tests/wp-unit/include/Core/Metas/Modules/DeletePostMetaModuleTestInOldFormat.php
@@ -1,0 +1,252 @@
+<?php
+
+namespace BulkWP\BulkDelete\Core\Metas\Modules;
+
+use BulkWP\Tests\WPCore\WPCoreUnitTestCase;
+
+/**
+ * Test Delete Post Meta Module.
+ *
+ * Tests \BulkWP\BulkDelete\Core\Metas\Modules\DeletePostMetaModule
+ *
+ * @since 6.0.0
+ */
+class DeletePostMetaModuleTest extends WPCoreUnitTestCase {
+	/**
+	 * The module that is getting tested.
+	 *
+	 * @var \BulkWP\BulkDelete\Core\Metas\Modules\DeletePostMetaModule
+	 */
+	protected $module;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->module = new DeletePostMetaModule();
+	}
+
+	/**
+	 * Add to test single post meta from the default post type.
+	 */
+	public function test_that_single_post_meta_can_be_deleted_from_default_post_type() {
+		// Create a post
+		$post = $this->factory->post->create( array( 'post_title' => 'Test Post' ) );
+
+		// Assign meta value to the post
+		add_post_meta( $post, 'time', '10/10/2018' );
+
+		$post_meta = get_post_meta( $post, 'time' );
+
+		// Assert that post meta have posts
+		$this->assertEquals( 1, count( $post_meta ) );
+
+		// call our method.
+		$delete_options = array(
+			'post_type'    => 'post',
+			'limit_to'     => -1,
+			'restrict'     => false,
+			'force_delete' => false,
+			'use_value'    => 'use_key',
+			'meta_key'     => 'time',
+			'date_op'      => '',
+			'days'         => '',
+		);
+
+		$meta_deleted = $this->module->delete( $delete_options );
+
+		$post_meta = get_post_meta( $post, 'time' );
+
+		// Assert that post meta does not have posts
+		$this->assertEquals( 0, count( $post_meta ) );
+	}
+
+	/**
+	 * Add to test more than one post meta from the default post type.
+	 */
+	public function test_that_more_than_one_post_meta_can_be_deleted_from_default_post_type() {
+		// Create a post
+		$post = $this->factory->post->create( array( 'post_title' => 'Test Post' ) );
+
+		// Assign meta value to the post
+		add_post_meta( $post, 'time', '10/10/2018' );
+		add_post_meta( $post, 'time', '11/11/2018' );
+		add_post_meta( $post, 'time', '12/12/2018' );
+
+		$post_meta = get_post_meta( $post, 'time' );
+		$this->assertEquals( 3, count( $post_meta ) );
+
+		// call our method.
+		$delete_options = array(
+			'post_type'    => 'post',
+			'limit_to'     => -1,
+			'restrict'     => false,
+			'force_delete' => false,
+			'use_value'    => 'use_key',
+			'meta_key'     => 'time',
+			'date_op'      => '',
+			'days'         => '',
+		);
+
+		$meta_deleted = $this->module->delete( $delete_options );
+
+		$post_meta = get_post_meta( $post, 'time' );
+		$this->assertEquals( 0, count( $post_meta ) );
+	}
+
+	/**
+	 * Add to test single post meta from the custom post type.
+	 */
+	public function test_that_single_post_meta_can_be_deleted_from_custom_post_type() {
+		// Create a post with custom post type
+		$post = $this->factory->post->create( array( 'post_title' => 'Test Post', 'post_type' => 'custom' ) );
+
+		// Assign meta value to the post
+		add_post_meta( $post, 'time', '10/10/2018' );
+
+		$post_meta = get_post_meta( $post, 'time' );
+		$this->assertEquals( 1, count( $post_meta ) );
+
+		// call our method.
+		$delete_options = array(
+			'post_type'    => 'custom',
+			'limit_to'     => -1,
+			'restrict'     => false,
+			'force_delete' => false,
+			'use_value'    => 'use_key',
+			'meta_key'     => 'time',
+			'date_op'      => '',
+			'days'         => '',
+		);
+
+		$meta_deleted = $this->module->delete( $delete_options );
+
+		$post_meta = get_post_meta( $post, 'time' );
+		$this->assertEquals( 0, count( $post_meta ) );
+	}
+
+	/**
+	 * Add to test more than one post meta from the custom post type.
+	 */
+	public function test_that_more_than_one_post_meta_can_de_deleted_from_custom_post_type() {
+		// Create a post with custom post type
+		$post = $this->factory->post->create( array( 'post_title' => 'Test Post', 'post_type' => 'custom' ) );
+
+		// Assign meta value to the post
+		add_post_meta( $post, 'time', '10/10/2018' );
+		add_post_meta( $post, 'time', '11/11/2018' );
+		add_post_meta( $post, 'time', '12/12/2018' );
+
+		$post_meta = get_post_meta( $post, 'time' );
+		$this->assertEquals( 3, count( $post_meta ) );
+
+		// call our method.
+		$delete_options = array(
+			'post_type'    => 'custom',
+			'limit_to'     => -1,
+			'restrict'     => false,
+			'force_delete' => false,
+			'use_value'    => 'use_key',
+			'meta_key'     => 'time',
+			'date_op'      => '',
+			'days'         => '',
+		);
+
+		$meta_deleted = $this->module->delete( $delete_options );
+
+		$post_meta = get_post_meta( $post, 'time' );
+		$this->assertEquals( 0, count( $post_meta ) );
+	}
+
+	/**
+	 * Add to test post meta delete from post published date.
+	 */
+	public function test_that_post_meta_deletion_be_restricted_by_post_older_than() {
+		// Create a post with past date
+		$date = date( 'Y-m-d H:i:s', strtotime( '-5 day' ) );
+		$post = $this->factory->post->create( array( 'post_title' => 'Test Post', 'post_date' => $date ) );
+
+		// Assign meta value to the post
+		add_post_meta( $post, 'time', '10/10/2018' );
+
+		$post_meta = get_post_meta( $post, 'time' );
+		$this->assertEquals( 1, count( $post_meta ) );
+
+		// call our method.
+		$delete_options = array(
+			'post_type'    => 'post',
+			'limit_to'     => -1,
+			'restrict'     => false,
+			'force_delete' => false,
+			'use_value'    => 'use_key',
+			'meta_key'     => 'time',
+			'date_op'      => 'before',
+			'days'         => '3',
+		);
+
+		$meta_deleted = $this->module->delete( $delete_options );
+
+		$post_meta = get_post_meta( $post, 'time' );
+		$this->assertEquals( 0, count( $post_meta ) );
+	}
+
+	/**
+	 * Add to test post meta delete from previous published with in x date.
+	 */
+	public function test_that_post_meta_deletion_be_restricted_by_posts_within_the_last_x_days() {
+		// Create a post with past date
+		$date = date( 'Y-m-d H:i:s', strtotime( '-3 day' ) );
+		$post = $this->factory->post->create( array( 'post_title' => 'Test Post', 'post_date' => $date ) );
+
+		// Assign meta value to the post
+		add_post_meta( $post, 'time', '10/10/2018' );
+
+		$post_meta = get_post_meta( $post, 'time' );
+		$this->assertEquals( 1, count( $post_meta ) );
+
+		// call our method.
+		$delete_options = array(
+			'post_type'    => 'post',
+			'limit_to'     => -1,
+			'restrict'     => false,
+			'force_delete' => false,
+			'use_value'    => 'use_key',
+			'meta_key'     => 'time',
+			'date_op'      => 'after',
+			'days'         => '5',
+		);
+
+		$meta_deleted = $this->module->delete( $delete_options );
+
+		$post_meta = get_post_meta( $post, 'time' );
+		$this->assertEquals( 0, count( $post_meta ) );
+	}
+
+	/**
+	 * Add to test delete post meta in batches.
+	 */
+	public function test_that_post_meta_can_be_deleted_in_batches() {
+		$posts = $this->factory->post->create_many( 20, array(
+			'post_type'   => 'post',
+		) );
+		foreach($posts as $post ){
+			// Assign meta value to the post
+			add_post_meta( $post, 'time', '10/10/2018' );
+		}
+
+		// call our method.
+		$delete_options = array(
+			'post_type'    => 'post',
+			'limit_to'     => 10,
+			'restrict'     => false,
+			'force_delete' => false,
+			'use_value'    => 'use_key',
+			'meta_key'     => 'time',
+			'date_op'      => '',
+			'days'         => '',
+		);
+
+		$meta_deleted = $this->module->delete( $delete_options );
+
+		$this->assertEquals( 10, $meta_deleted );
+	}
+}

--- a/tests/wp-unit/include/Core/Metas/Modules/DeletePostMetaModuleTestInOldFormat.php
+++ b/tests/wp-unit/include/Core/Metas/Modules/DeletePostMetaModuleTestInOldFormat.php
@@ -11,7 +11,7 @@ use BulkWP\Tests\WPCore\WPCoreUnitTestCase;
  *
  * @since 6.0.0
  */
-class DeletePostMetaModuleTest extends WPCoreUnitTestCase {
+class DeletePostMetaModuleTestInOldFormat extends WPCoreUnitTestCase {
 	/**
 	 * The module that is getting tested.
 	 *


### PR DESCRIPTION
@sudar is checking why `date_op, days` are required even when `restrict` is set to false
Fix #615.